### PR TITLE
pv.perpetuity returns a negative value

### DIFF
--- a/R/pv.perpetuity.R
+++ b/R/pv.perpetuity.R
@@ -19,7 +19,7 @@ pv.perpetuity <- function(r, pmt, g=0, type=0){
     if(g >= r){
       print("Error: g is not smaller than r!")
     }else{
-      pv <- (pmt / (r - g)) * ((1 + r)^type) * (-1)
+      pv <- (pmt / (r - g)) * ((1 + r)^type)
       return(pv) 
     }
   }


### PR DESCRIPTION
Currently `pv.perpetuity` returns a negative value, which seems to be wrong. 

Consider this example of 2000 payment with 2% discount rate to infinity: 

    > pv.perpetuity(0.02, 1000)
    [1] -50000

A positive payment in the future can never yield a negative PV. At most the PV can go to 0 if the discounting rate is large enough. 

This patch ensures the resultant PV is positive. 

```
> pv.perpetuity(0.02, 1000)
[1] 50000
```

For an absurdly large discounting factor, the PV tends towards 0 but never becomes negative: 

```
> pv.perpetuity(1000000000, 1000)
[1] 0.000001
```