### PR TITLE
improve accuracy of irr()

### DIFF
--- a/R/irr.R
+++ b/R/irr.R
@@ -10,5 +10,6 @@
 irr <- function(cf){
         n <- length(cf)
         subcf <- cf[2:n]
-        uniroot(function(r) -1 * pv.uneven(r, subcf) + cf[1], interval=c(1e-10,1e10),extendInt="yes")$root 
+        uniroot(function(r) -1 * pv.uneven(r, subcf) + cf[1], 
+                interval=c(1e-10,1e10), extendInt="yes", tol = .Machine$double.eps)$root 
 }


### PR DESCRIPTION
This patch improves the accuracy of `irr()`. 

This came from my inability to accurately match results from `financial::cf()` and `irr()`. Take for instance this example: 

```
> options("digits"=14)
> cf(c(-123400, 36200, 54800, 48100))$irr/100
[1] 0.05961637856733
> irr(c(-123400, 36200, 54800, 48100))
[1] 0.059597865486905
```

You can see that the results match only up to 3 digits, which may be unsatisfactory for those trying to benchmark results. With this patch the accuracy is improved to 14 digits, which should cover most use cases: 
```
> cf(c(-123400, 36200, 54800, 48100))$irr/100
[1] 0.05961637856733
> irr(c(-123400, 36200, 54800, 48100))
[1] 0.05961637856733
```

Now `irr()` can also replicate results to much greater precision from, say, this SO question: 
http://stackoverflow.com/questions/21743967/different-results-for-irr-computation-between-r-and-ms-excel